### PR TITLE
Fix English comment in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 
 COPY --from=builder /app/build/libs/authentication-server-0.0.1-SNAPSHOT.jar app.jar
 
-# Limitar memoria
+# Limit memory usage
 ENV JAVA_OPTS="-Xms256m -Xmx512m"
 
 EXPOSE 8090


### PR DESCRIPTION
## Summary
- replace Spanish comment in Dockerfile with English for consistency

## Testing
- `./gradlew test --no-daemon` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6856d03723c0832fa4f3b02717828ae6