### PR TITLE
Fix SpringApplication stubbing in tests

### DIFF
--- a/src/test/java/com/joga/app/authenticationserver/AuthenticationServerApplicationTest.java
+++ b/src/test/java/com/joga/app/authenticationserver/AuthenticationServerApplicationTest.java
@@ -15,8 +15,8 @@ class AuthenticationServerApplicationTest {
     void test(){
         try (MockedStatic<SpringApplication> mocked = mockStatic(SpringApplication.class)) {
 
-            mocked.when(() -> { SpringApplication.run(AuthenticationServerApplication.class,
-                    "foo", "bar"); })
+            mocked.when(() -> SpringApplication.run(AuthenticationServerApplication.class,
+                    "foo", "bar"))
                 .thenReturn(Mockito.mock(ConfigurableApplicationContext.class));
 
             AuthenticationServerApplication.main(new String[] { "foo", "bar" });


### PR DESCRIPTION
## Summary
- fix stubbing of `SpringApplication.run` in `AuthenticationServerApplicationTest`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6856d02a9bf4832fa45a49095ce02c69