### PR TITLE
Rename constant in ConfigServerDecryptClientTest

### DIFF
--- a/src/test/java/com/joga/app/authenticationserver/ConfigServerDecryptClientTest.java
+++ b/src/test/java/com/joga/app/authenticationserver/ConfigServerDecryptClientTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 @ExtendWith(MockitoExtension.class)
 class ConfigServerDecryptClientTest {
 
-    public static final String HTTP_LOCALHOST_8888_DECRYPT = "https://config-server-develop.up.railway.app/decrypt";
+    public static final String CONFIG_SERVER_DECRYPT_URL = "https://config-server-develop.up.railway.app/decrypt";
     private ConfigServerDecryptClient client;
     private MockRestServiceServer mockServer;
     private RestTemplate restTemplate;
@@ -54,7 +54,7 @@ class ConfigServerDecryptClientTest {
         String input = "{cipher}secret";
         String expected = "my-password";
 
-        mockServer.expect(once(), requestTo(HTTP_LOCALHOST_8888_DECRYPT))
+        mockServer.expect(once(), requestTo(CONFIG_SERVER_DECRYPT_URL))
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess(expected, MediaType.TEXT_PLAIN));
 
@@ -69,7 +69,7 @@ class ConfigServerDecryptClientTest {
         String encryptedValue = "{cipher}my-encrypted";
         String expectedDecryptedValue = "my-decrypted";
 
-        mockServer.expect(once(), requestTo(HTTP_LOCALHOST_8888_DECRYPT))
+        mockServer.expect(once(), requestTo(CONFIG_SERVER_DECRYPT_URL))
                 .andExpect(method(HttpMethod.POST))
                 .andRespond(withSuccess(expectedDecryptedValue, MediaType.TEXT_PLAIN));
 


### PR DESCRIPTION
## Summary
- rename `HTTP_LOCALHOST_8888_DECRYPT` constant to `CONFIG_SERVER_DECRYPT_URL`
- update references to new constant name

## Testing
- `gradlew test` *(fails: Unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_b_6856d053a8e8832f87df4a95f1cb44f4